### PR TITLE
Avoid calling `.setElementClass` with a value of undefined (closes #329)

### DIFF
--- a/lib/src/icon-mdi/icon-mdi.directive.ts
+++ b/lib/src/icon-mdi/icon-mdi.directive.ts
@@ -47,7 +47,7 @@ export class MzIconMdiDirective extends HandlePropChanges implements AfterViewIn
       this.renderer.setElementClass(this.elementRef.nativeElement, previousValue, false);
     }
     if (this.align) {
-      this.renderer.setElementClass(this.elementRef.nativeElement, this.align, !!this.align);
+      this.renderer.setElementClass(this.elementRef.nativeElement, this.align, true);
     }
   }
 

--- a/lib/src/icon-mdi/icon-mdi.directive.ts
+++ b/lib/src/icon-mdi/icon-mdi.directive.ts
@@ -46,7 +46,9 @@ export class MzIconMdiDirective extends HandlePropChanges implements AfterViewIn
     if (previousValue) {
       this.renderer.setElementClass(this.elementRef.nativeElement, previousValue, false);
     }
-    this.renderer.setElementClass(this.elementRef.nativeElement, this.align, !!this.align);
+    if (this.align) {
+      this.renderer.setElementClass(this.elementRef.nativeElement, this.align, !!this.align);
+    }
   }
 
   handleFlip(previousValue?: string) {

--- a/lib/src/icon-mdi/icon-mdi.directive.unit.spec.ts
+++ b/lib/src/icon-mdi/icon-mdi.directive.unit.spec.ts
@@ -116,11 +116,11 @@ describe('MzIconMdiDirective:unit', () => {
 
     it('should not add align css class when align is not provided', () => {
 
-      spyOn(renderer, 'setElementClass');
+      const spy = spyOn(renderer, 'setElementClass');
 
       directive.handleAlign();
 
-      expect(renderer.setElementClass).toHaveBeenCalledWith(mockElementRef.nativeElement, directive.align, false);
+      expect(spy.calls.count()).toEqual(0);
     });
 
     it('should remove previous css class when provided', () => {

--- a/lib/src/icon/icon.directive.ts
+++ b/lib/src/icon/icon.directive.ts
@@ -43,7 +43,7 @@ export class MzIconDirective extends HandlePropChanges implements AfterViewInit 
       this.renderer.setElementClass(this.elementRef.nativeElement, previousValue, false);
     }
     if (this.align) {
-      this.renderer.setElementClass(this.elementRef.nativeElement, this.align, !!this.align);
+      this.renderer.setElementClass(this.elementRef.nativeElement, this.align, true);
     }
   }
 
@@ -56,7 +56,7 @@ export class MzIconDirective extends HandlePropChanges implements AfterViewInit 
       this.renderer.setElementClass(this.elementRef.nativeElement, previousValue, false);
     }
     if (this.size) {
-      this.renderer.setElementClass(this.elementRef.nativeElement, this.size, !!this.size);
+      this.renderer.setElementClass(this.elementRef.nativeElement, this.size, true);
     }
   }
 }

--- a/lib/src/icon/icon.directive.ts
+++ b/lib/src/icon/icon.directive.ts
@@ -42,7 +42,9 @@ export class MzIconDirective extends HandlePropChanges implements AfterViewInit 
     if (previousValue) {
       this.renderer.setElementClass(this.elementRef.nativeElement, previousValue, false);
     }
-    this.renderer.setElementClass(this.elementRef.nativeElement, this.align, !!this.align);
+    if (this.align) {
+      this.renderer.setElementClass(this.elementRef.nativeElement, this.align, !!this.align);
+    }
   }
 
   handleIcon() {
@@ -53,6 +55,8 @@ export class MzIconDirective extends HandlePropChanges implements AfterViewInit 
     if (previousValue) {
       this.renderer.setElementClass(this.elementRef.nativeElement, previousValue, false);
     }
-    this.renderer.setElementClass(this.elementRef.nativeElement, this.size, !!this.size);
+    if (this.size) {
+      this.renderer.setElementClass(this.elementRef.nativeElement, this.size, !!this.size);
+    }
   }
 }

--- a/lib/src/icon/icon.directive.unit.spec.ts
+++ b/lib/src/icon/icon.directive.unit.spec.ts
@@ -62,7 +62,7 @@ describe('MzIconDirective:unit', () => {
 
   describe('initHandlers', () => {
 
-    it('should initilialize handlers correctly', () => {
+    it('should initialize handlers correctly', () => {
 
       const handlers = {
          align: 'handleAlign',
@@ -114,11 +114,11 @@ describe('MzIconDirective:unit', () => {
 
     it('should not add align css class when align is not provided', () => {
 
-      spyOn(renderer, 'setElementClass');
+      const spy = spyOn(renderer, 'setElementClass');
 
       directive.handleAlign();
 
-      expect(renderer.setElementClass).toHaveBeenCalledWith(mockElementRef.nativeElement, directive.align, false);
+      expect(spy.calls.count()).toEqual(0);
     });
 
     it('should remove previous css class when provided', () => {
@@ -162,11 +162,11 @@ describe('MzIconDirective:unit', () => {
 
     it('should not add size css class when size is not provided', () => {
 
-      spyOn(renderer, 'setElementClass');
+      const spy = spyOn(renderer, 'setElementClass');
 
       directive.handleSize();
 
-      expect(renderer.setElementClass).toHaveBeenCalledWith(mockElementRef.nativeElement, directive.size, false);
+      expect(spy.calls.count()).toEqual(0);
     });
 
     it('should remove previous css class when provided', () => {


### PR DESCRIPTION
Avoid calling `.setElementClass` with a value of `undefined` to prevent issues with Angular Universal using the [domino](https://github.com/fgnass/domino) package to render the application.

Fix #329